### PR TITLE
fix(ci): wait for exist-db healthy and combine npm security updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           docker run -dit -p 8080:8080 -v ${{ github.workspace }}/build:/exist/autodeploy \
           --name exist --rm --health-interval=2s --health-start-period=4s \
           duncdrum/existdb:${{ matrix.exist-version }}
-          sleep 10s
+          sleep 30s
 
       # Test
       - name: Run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -2779,9 +2779,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -3122,9 +3122,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
-      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
+      "version": "11.19.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.19.0.tgz",
+      "integrity": "sha512-SDd/hHg3KqHE5Ht2NHWxNYNtqCQ2pXAPLl6OtQhPyED5PHsRfrOtO199MZTIG2cQoQ1ZRI9t28shrD+2cr3AAw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -3203,8 +3203,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.8.0",
-        "@npmcli/config": "^10.11.0",
+        "@npmcli/arborist": "^9.9.1",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -3228,11 +3228,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.10",
-        "libnpmexec": "^10.3.0",
-        "libnpmfund": "^7.0.24",
+        "libnpmdiff": "^8.1.12",
+        "libnpmexec": "^10.3.2",
+        "libnpmfund": "^7.0.26",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.10",
+        "libnpmpack": "^9.1.12",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -3248,7 +3248,7 @@
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
@@ -3257,11 +3257,11 @@
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.8.4",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -3363,7 +3363,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.8.0",
+      "version": "9.9.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3411,7 +3411,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.11.0",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3756,7 +3756,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4130,12 +4130,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.10",
+      "version": "8.1.12",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.1",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -4149,13 +4149,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.3.0",
+      "version": "10.3.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.1",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -4172,12 +4172,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.24",
+      "version": "7.0.26",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0"
+        "@npmcli/arborist": "^9.9.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4197,12 +4197,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.10",
+      "version": "9.1.12",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.1",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -4571,13 +4571,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4782,7 +4782,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.8.4",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4907,7 +4907,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.16",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -5003,7 +5003,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.26.0",
+      "version": "6.27.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary
- Combine #77 (`js-yaml` 4.3.1) with the `npm` 11.19.0 bundled-dep bumps Dependabot could not open.
- Sleep 30s before smoke tests so Docker can report `healthy`. Probe flags stay `interval=2s` / `start-period=4s`.

## Test plan
- [x] `build (latest, 21)` and `build (release, 11)` pass, including `container reports healthy to docker`.