### PR TITLE
Index configuration for the serial-set collection

### DIFF
--- a/serial-set.xconf
+++ b/serial-set.xconf
@@ -1,0 +1,12 @@
+<collection xmlns="http://exist-db.org/collection-config/1.0">
+    <index xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <!-- Range index backing the region/subject term filters of the
+             pre-1861 Serial Set pages in hsg-jinks (its serial-set.xqm
+             filters the ~2800 bibl records on tei:term string values and
+             tei:term/@type); raised in review of hsg-jinks PR #46. -->
+        <range>
+            <create qname="tei:term" type="xs:string"/>
+            <create qname="@type" type="xs:string"/>
+        </range>
+    </index>
+</collection>


### PR DESCRIPTION
Adds the missing `serial-set.xconf`, following the repo's per-collection xconf convention (`pre-install.xql` installs any `<collection>.xconf` automatically): a range index on `tei:term` string values and `@type`, backing the region/subject filters of the pre-1861 Serial Set pages in hsg-jinks ([hsg-jinks PR #46](https://github.com/HistoryAtState/hsg-jinks/pull/46) review, tracked as [OP#1312](https://jtes.openproject.eu/work_packages/1312)).

Verified on a deployed instance (eXist 7 devcontainer): after storing the xconf and reindexing, the range index populates (612 distinct term keys) and the `tei:term[@type='region']/[@type='subject']` equality filters return the expected records (Africa/Egypt → 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)